### PR TITLE
Add support for epub

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,21 @@ Writing is challenging. But I found it enormously helpful, as an exercise toward
 building a deeper understanding of how things work. If one can explain something,
 it means that one understands it. And this is the purpose of these notes. I hope
 I've learned, and I also hope you too!
+
+## Building
+
+To build the book:
+
+1. [Install `mdbook`](https://rust-lang.github.io/mdBook/guide/installation.html)
+2. Clone the repository (`git clone https://github.com/blasrodri/spaceship-go.git`)
+3. Run `mdbook`
+
+To optionally build the epub file format, install `mdbook-epub`:
+
+```
+cargo install mdbook-epub --version 0.4.14-alpha.0
+# Then run mdbook
+mdbook
+```
+
+Output will be saved as `book/Spaceship Go.epub`.

--- a/book.toml
+++ b/book.toml
@@ -8,3 +8,4 @@ title = "Spaceship Go"
 [output.epub]
 cover-image = "img/cover.svg"
 additional-resources = ["img/cover.svg"]
+optional = true

--- a/book.toml
+++ b/book.toml
@@ -4,3 +4,7 @@ language = "en"
 multilingual = false
 src = "src"
 title = "Spaceship Go"
+
+[output.epub]
+cover-image = "img/cover.svg"
+additional-resources = ["img/cover.svg"]


### PR DESCRIPTION
Marked the EPUB build as optional since the EPUB plugin isn't bundled with mdbook. The plugin also doesn't work with the latest mdbook, and needs an alpha version, so I've noted that in the README.